### PR TITLE
Adds .html.erb to erb language extensions for toggleTags command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }, {
 			"id": "erb",
       "aliases": ["erb", "Encapsulated Ruby", "HTML Ruby"],
-			"extensions": [".erb", ".rhtml", ".rhtm"],
+			"extensions": [".erb", ".rhtml", ".rhtm", ".html.erb"],
       "configuration": "./language_configuration.erb.json"
 		}],
     "grammars": [{


### PR DESCRIPTION
Previously the `` ctrl+shift+` `` keybinding did not work out-of-the-box in `*.html.erb` files (the default extension for erb views in Rails). This PR adds that file extension to the `erb` language definition in `package.json`.

This may have been the source of https://github.com/vortizhe/vscode-ruby-erb/issues/5